### PR TITLE
Removing javax restriction from packaging

### DIFF
--- a/src/main/java/com/tonicsystems/jarjar/KeepProcessor.java
+++ b/src/main/java/com/tonicsystems/jarjar/KeepProcessor.java
@@ -75,7 +75,7 @@ class KeepProcessor extends Remapper implements JarProcessor
     }
 
     public String map(String key) {
-        if (key.startsWith("java/") || key.startsWith("javax/"))
+        if (key.startsWith("java/"))
             return null;
         curSet.add(key);
         return null;


### PR DESCRIPTION
... like javax.inject.**

in the context of Maven I don't believe we're ever going to give JarJar direct access to the JRE where
  everything can be pulled in.

  in my case here where i am making a self-contained JSR330-based server removing the javax restricted resulted
  in a working uber jar.
